### PR TITLE
clickhouse-cityhash 1.0.2.5 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,23 +1,22 @@
 {% set name = "clickhouse-cityhash" %}
-{% set version = "1.0.2.4" %}
-{% set sha256 = "7b3125d7d0aa13c2cc4e7583a965a6bfb0aa96a12131475b442552bacb55f4f8" %}
+{% set version = "1.0.2.5" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  fn: {{ name }}-{{ version }}.tar.gz
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: {{ sha256 }}
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name|replace('-', '_') }}-{{ version }}.tar.gz
+  sha256: 4f98ef81b21f0d4dad58247bea40bafc098cf6ffa0ede699882d4a42eac3ed79
 
 build:
   number: 0
   skip: True  # [win]
-  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv"
+  script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
 
 requirements:
   build:
+    - {{ stdlib('c') }}
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
   host:
@@ -25,17 +24,21 @@ requirements:
     - python
     - setuptools
     - wheel
-    - cython
+    - cython >=3.0,<3.1
   run:
     - python
 
 test:
+  source_files:
+    - tests/test_cityhash.py
   imports:
     - clickhouse_cityhash
   requires:
     - pip
+    - pytest
   commands:
     - pip check
+    - pytest -v tests/test_cityhash.py
 
 about:
   home: https://github.com/xzkostyan/clickhouse-cityhash


### PR DESCRIPTION
clickhouse-cityhash 1.0.2.5 

**Destination channel:** Defaults

### Links

- [PKG-12130]
- dev_url:        https://github.com/xzkostyan/clickhouse-cityhash/tree/1.0.2.5
- conda_forge:    https://github.com/conda-forge/clickhouse-cityhash-feedstock
- pypi:           https://pypi.org/project/clickhouse-cityhash/1.0.2.5
- pypi inspector: https://inspector.pypi.io/project/clickhouse-cityhash/1.0.2.5

### Explanation of changes:

- new version number


[PKG-12130]: https://anaconda.atlassian.net/browse/PKG-12130?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ